### PR TITLE
[Fix] add type hints for config and terminal util functions

### DIFF
--- a/src/hncli/cli.py
+++ b/src/hncli/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from rich.progress import Progress
 from rich.markup import escape
 import webbrowser
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
 import textwrap
 from hncli import config, cache
 import subprocess
@@ -31,7 +31,8 @@ USER_URL = f"{BASE_URL}/user"
 HN_WEB_URL = "https://news.ycombinator.com"
 
 # Load configuration
-def get_config_value(key, default=None):
+
+def get_config_value(key: str, default: Any = None) -> Any:
     """Get a configuration value with fallback to default."""
     try:
         return config.get_setting(key)
@@ -117,7 +118,7 @@ def truncate_text(text: str, max_length: int = 80) -> str:
         return text[:max_length-3] + "..."
     return text or ""
 
-def get_terminal_size():
+def get_terminal_size() -> Tuple[int, int]:
     """Get the current terminal size."""
     try:
         # Get terminal size
@@ -127,7 +128,7 @@ def get_terminal_size():
         # Default to standard size if detection fails
         return 80, 24
 
-def calculate_stories_per_page():
+def calculate_stories_per_page() -> int:
     """
     Calculate how many stories to display per page based on terminal size.
 


### PR DESCRIPTION
## Summary
- add typing imports for Any and Tuple
- annotate `get_config_value`, `get_terminal_size`, `calculate_stories_per_page`
- run formatting and type checks

## Testing
- `flake8 src/hncli` *(fails: command not found)*
- `mypy src/hncli` *(fails: cannot find stubs)*
- `python -m pytest` *(fails: No module named pytest)*