### PR TITLE
[Feature] open links based on config

### DIFF
--- a/src/hncli/cli.py
+++ b/src/hncli/cli.py
@@ -564,9 +564,13 @@ def user(username: str) -> None:
     
     console.print(Panel(user_table, title=f"[bold]User Profile: {username}[/bold]"))
     
-    # Ask if user wants to open in browser
-    if typer.confirm("\nOpen user profile in browser?"):
+    # Automatically open in browser based on configuration
+    if get_config_value("open_links_in_browser", True):
         webbrowser.open(f"{HN_WEB_URL}/user?id={username}")
+    else:
+        # Ask if user wants to open in browser when automatic opening is disabled
+        if typer.confirm("\nOpen user profile in browser?"):
+            webbrowser.open(f"{HN_WEB_URL}/user?id={username}")
 
 @app.command()
 def search(query: str, limit: int = None) -> None:
@@ -670,8 +674,14 @@ def search(query: str, limit: int = None) -> None:
 @app.command()
 def open(story_id: int) -> None:
     """Open a story in the web browser."""
-    webbrowser.open(f"{HN_WEB_URL}/item?id={story_id}")
-    console.print(f"Opening story {story_id} in browser...")
+    url = f"{HN_WEB_URL}/item?id={story_id}"
+    if get_config_value("open_links_in_browser", True):
+        webbrowser.open(url)
+        console.print(f"Opening story {story_id} in browser...")
+    else:
+        if typer.confirm("Open story in browser?"):
+            webbrowser.open(url)
+            console.print(f"Opening story {story_id} in browser...")
 
 @app.command()
 def config_set(key: str, value: str) -> None:

--- a/tests/test_browser_behavior.py
+++ b/tests/test_browser_behavior.py
@@ -1,0 +1,41 @@
+from typer.testing import CliRunner
+import hncli.cli as cli
+
+runner = CliRunner()
+
+def test_open_auto(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "get_config_value", lambda key, default=None: True)
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: calls.append(url))
+    result = runner.invoke(cli.app, ["open", "123"])
+    assert result.exit_code == 0
+    assert calls == [f"{cli.HN_WEB_URL}/item?id=123"]
+
+def test_open_prompt(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "get_config_value", lambda key, default=None: False)
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: calls.append(url))
+    monkeypatch.setattr(cli.typer, "confirm", lambda *a, **kw: True)
+    result = runner.invoke(cli.app, ["open", "456"])
+    assert result.exit_code == 0
+    assert calls == [f"{cli.HN_WEB_URL}/item?id=456"]
+
+def test_user_auto(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "get_config_value", lambda key, default=None: True)
+    monkeypatch.setattr(cli, "get_user", lambda u: {"created": 0, "karma": 1, "about": ""})
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: calls.append(url))
+    monkeypatch.setattr(cli.typer, "confirm", lambda *a, **kw: (_ for _ in ()).throw(AssertionError("confirm called")))
+    result = runner.invoke(cli.app, ["user", "alice"])
+    assert result.exit_code == 0
+    assert calls == [f"{cli.HN_WEB_URL}/user?id=alice"]
+
+def test_user_prompt(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "get_config_value", lambda key, default=None: False)
+    monkeypatch.setattr(cli, "get_user", lambda u: {"created": 0, "karma": 1, "about": ""})
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: calls.append(url))
+    monkeypatch.setattr(cli.typer, "confirm", lambda *a, **kw: True)
+    result = runner.invoke(cli.app, ["user", "bob"])
+    assert result.exit_code == 0
+    assert calls == [f"{cli.HN_WEB_URL}/user?id=bob"]


### PR DESCRIPTION
## Summary
- read `open_links_in_browser` via `get_config_value`
- respect the setting in `user` and `open` commands
- add tests for both behaviours

## Testing
- `flake8 src tests` *(fails: command not found)*
- `mypy src` *(fails: missing stubs)*
- `python -m pytest -q` *(fails: No module named pytest)*