### PR TITLE
[Fix] add wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ cd hncli
 hn top         # Show top stories
 hn new         # Show new stories
 hn search ai   # Search for AI-related stories
+
+# If you prefer not to install the `hn` entrypoint, you can run the
+# wrapper script directly:
+./run-hncli.sh top
 ```
 
 ## Installation

--- a/run-hncli.sh
+++ b/run-hncli.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Wrapper script to run the Hacker News CLI
+# Usage: ./run-hncli.sh [arguments]
+
+python -m hncli.cli "$@"


### PR DESCRIPTION
## Summary
- add `run-hncli.sh` wrapper
- document running the wrapper in README

## Testing
- `python -m pytest` *(fails: No module named pytest)*
- `mypy src` *(fails: many missing stubs and typing errors)*
- `flake8 src` *(fails: command not found)*