### PR TITLE
[Feature] Add theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Available configuration options:
   - Note: The actual number displayed may be lower depending on terminal size
 - `max_comment_depth`: Maximum depth of comments to display (default: 3)
 - `open_links_in_browser`: Whether to automatically open links in browser (default: true)
-- `color_theme`: Color theme to use (default: "default")
+ - `color_theme`: Color theme to use (default: "default"). Available themes: `default`, `dark`.
 - `cache_timeout_minutes`: Cache timeout in minutes (default: 5)
 
 ## Cache Management

--- a/src/hncli/cli.py
+++ b/src/hncli/cli.py
@@ -14,7 +14,7 @@ from rich.markup import escape
 import webbrowser
 from typing import Any, List, Optional, Tuple
 import textwrap
-from hncli import config, cache
+from hncli import config, cache, themes
 import os
 import shutil
 import re
@@ -41,7 +41,8 @@ if "ctx" in inspect.signature(click.Parameter.make_metavar).parameters:
     click.Parameter.make_metavar = _patched_make_metavar  # type: ignore[assignment]
 
 app = typer.Typer(help="Hacker News CLI")
-console = Console()
+theme_name = config.get_setting("color_theme")
+console = Console(theme=themes.get_theme(theme_name))
 
 # Base URLs for the Hacker News API
 BASE_URL = "https://hacker-news.firebaseio.com/v0"

--- a/src/hncli/themes.py
+++ b/src/hncli/themes.py
@@ -1,0 +1,23 @@
+from rich.theme import Theme
+
+DEFAULT_THEME = Theme({
+    "info": "cyan",
+    "warning": "magenta",
+    "error": "bold red",
+})
+
+DARK_THEME = Theme({
+    "info": "bright_cyan",
+    "warning": "bright_magenta",
+    "error": "bold bright_red",
+})
+
+_THEMES = {
+    "default": DEFAULT_THEME,
+    "dark": DARK_THEME,
+}
+
+def get_theme(name: str) -> Theme:
+    """Return theme by name or default if not found."""
+    return _THEMES.get(name, DEFAULT_THEME)
+

--- a/tests/test_console_theme.py
+++ b/tests/test_console_theme.py
@@ -1,0 +1,20 @@
+import importlib
+import types
+
+from hncli import themes
+
+
+def test_console_uses_configured_theme(monkeypatch):
+    captured = {}
+
+    def fake_console(*args, **kwargs):
+        captured["theme"] = kwargs.get("theme")
+        return types.SimpleNamespace(print=lambda *a, **kw: None)
+
+    import hncli.cli as cli
+    monkeypatch.setattr(cli, "Console", fake_console)
+    monkeypatch.setattr(cli.config, "get_setting", lambda k: "dark" if k == "color_theme" else cli.config.DEFAULT_CONFIG.get(k))
+
+    cli = importlib.reload(cli)
+    assert captured["theme"] is themes.get_theme("dark")
+


### PR DESCRIPTION
## Notes
- Added Rich theme definitions and ability to select them via `color_theme`

## Summary
- provide `DEFAULT_THEME` and `DARK_THEME` in new `themes.py`
- load the configured theme when constructing `Console`
- document available themes in README
- test that the console uses the configured theme

## Testing
- `python -m flake8 src tests` *(fails: No module named flake8)*
- `python -m mypy src/hncli` *(fails: missing type stubs and other errors)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: typer/hncli)*